### PR TITLE
postConditilonHandlerの修正

### DIFF
--- a/script/init.sql
+++ b/script/init.sql
@@ -15,6 +15,7 @@ CREATE TABLE `task` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 CREATE TABLE `condition` (
   `condition_id` int(11) NOT NULL AUTO_INCREMENT,
+  `user` text NOT NULL,
   `condition` text NOT NULL,
   PRIMARY KEY (`condition_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/condition.go
+++ b/src/condition.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 )
@@ -52,19 +53,23 @@ func deleteConditionHandler(c echo.Context) error {
 	var payload AuthHeader
 	(&echo.DefaultBinder{}).BindHeaders(c, &payload)
 	userId := payload.UserId
-
-	deleteid := c.Param("id")
-	var condition Condition
-
 	
-	err := db.Get(&condition, "SELECT * FROM `condition` WHERE `condition_id` =?", deleteid)
+	//idのint変換
+	deleteidstr := c.Param("id")
+	deleteid, err := strconv.Atoi(deleteidstr)
+	if err!= nil {
+    return c.String(http.StatusBadRequest, err.Error())
+  }
+
+	var condition Condition
+	err = db.Get(&condition, "SELECT * FROM `condition` WHERE `condition_id` =?", deleteid)
 	if err != nil {
 		fmt.Println(err)
 		return c.String(http.StatusInternalServerError, err.Error())
 	}
 
 	//他ユーザーによる削除を制限
-	if condition.User!= userId {
+	if condition.User != userId {
 		return c.String(http.StatusForbidden, "Forbidden")
 	}
 

--- a/src/condition.go
+++ b/src/condition.go
@@ -7,14 +7,38 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-
-
 func getConditionHandler(c echo.Context) error {
-	conditions := &[]Condition{}
-	if err := db.Select(&conditions, "SELECT * FROM condition"); err != nil {
+	var conditions []Condition
+	if err := db.Select(&conditions, "SELECT * FROM `condition`"); err != nil {
 		fmt.Println(err)
 	}
 	return c.JSON(http.StatusOK, conditions)
 }
 
+func postConditionHandler(c echo.Context) error {
+	conditionreq := &ConditionRequestBody{}
+	err := c.Bind(conditionreq)
 
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, err)
+	}
+
+	if len(conditionreq.Name) == 0 {
+		return c.JSON(http.StatusBadRequest, "Name cannot be empty")
+	}
+
+	_, err = db.Exec("INSERT INTO `condition` (`condition`) VALUES(?)", conditionreq.Name)
+
+	if err != nil {
+		fmt.Println(err)
+		return c.String(http.StatusInternalServerError, err.Error())
+	}
+
+	var condition Condition
+	err = db.Get(&condition.Id, "SELECT `condition_id` FROM `condition` WHERE `condition` = ? ORDER BY `condition_id` DESC", conditionreq.Name)
+	if err != nil {
+		fmt.Println(err)
+		return c.String(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, condition)
+}

--- a/src/condition.go
+++ b/src/condition.go
@@ -14,7 +14,7 @@ func getConditionHandler(c echo.Context) error {
 	userId := payload.UserId
 
 	var conditions []Condition
-	if err := db.Select(&conditions, "SELECT * FROM `condition` WHERE `user`=?", userId); err != nil {
+	if err := db.Select(&conditions, "SELECT `condition_id`, `condition` FROM `condition` WHERE `user`=?", userId); err != nil {
 		fmt.Println(err)
 		return c.String(http.StatusInternalServerError, err.Error())
 	}
@@ -82,6 +82,9 @@ func deleteConditionHandler(c echo.Context) error {
 	if condition.User != userId {
 		return c.String(http.StatusForbidden, "Forbidden")
 	}
+
+	//ユーザー情報はレスポンスに含まない
+	condition.User=""
 
 	//消去実行
 	_, err = db.Exec("DELETE FROM `condition` WHERE `condition_id` =?", deleteid)

--- a/src/condition.go
+++ b/src/condition.go
@@ -11,6 +11,7 @@ func getConditionHandler(c echo.Context) error {
 	var conditions []Condition
 	if err := db.Select(&conditions, "SELECT * FROM `condition`"); err != nil {
 		fmt.Println(err)
+		return c.String(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, conditions)
 }

--- a/src/condition.go
+++ b/src/condition.go
@@ -40,13 +40,15 @@ func postConditionHandler(c echo.Context) error {
 		return c.String(http.StatusInternalServerError, err.Error())
 	}
 
-	var condition Condition
-	err = db.Get(&condition.Id, "SELECT `condition_id` FROM `condition` WHERE `condition` = ? ORDER BY `condition_id` DESC", conditionreq.Name)
+	var condition int
+	err = db.Get(&condition, "SELECT `condition_id` FROM `condition` WHERE `condition` = ? ORDER BY `condition_id` DESC", conditionreq.Name)
 	if err != nil {
 		fmt.Println(err)
 		return c.String(http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, condition)
+	conditionstr := strconv.Itoa(condition)
+	return c.String(http.StatusOK, conditionstr)
+	
 }
 
 func deleteConditionHandler(c echo.Context) error {

--- a/src/main.go
+++ b/src/main.go
@@ -57,9 +57,8 @@ func main() {
 	e.POST("/task", postTaskHandler)
 
 	e.GET("/condition", getConditionHandler)
-
 	e.POST("/condition", postConditionHandler)
-
+	e.PUT("/condition/:id", putConditionHandler)
 	e.DELETE("/condition/:id", deleteConditionHandler)
 
 

--- a/src/main.go
+++ b/src/main.go
@@ -59,6 +59,8 @@ func main() {
 
 	e.POST("/condition", postConditionHandler)
 
+	e.DELETE("/condition/:id", deleteConditionHandler)
+
 	e.Start(":8080")
 }
 func pingHandler(c echo.Context) error {

--- a/src/main.go
+++ b/src/main.go
@@ -56,7 +56,9 @@ func main() {
 	e.GET("/task", getTaskHandler)
 
 	e.GET("/condition", getConditionHandler)
-	
+
+	e.POST("/condition", postConditionHandler)
+
 	e.Start(":8080")
 }
 func pingHandler(c echo.Context) error {

--- a/src/main.go
+++ b/src/main.go
@@ -55,15 +55,13 @@ func main() {
 	e.GET("/tasktest", getTaskTestHandler)
 	e.GET("/task", getTaskHandler)
 	e.POST("/task", postTaskHandler)
+	e.PUT("/task/:id", putTaskHandler)
+	e.DELETE("/task/:id", deleteTaskHandler)
 
 	e.GET("/condition", getConditionHandler)
 	e.POST("/condition", postConditionHandler)
 	e.PUT("/condition/:id", putConditionHandler)
 	e.DELETE("/condition/:id", deleteConditionHandler)
-
-
-	e.PUT("/task/:id", putTaskHandler)
-	e.DELETE("/task/:id", deleteTaskHandler)
 
 	e.Start(":8080")
 }

--- a/src/main.go
+++ b/src/main.go
@@ -54,7 +54,7 @@ func main() {
 	e.GET("/ping", pingHandler)
 	e.GET("/tasktest", getTaskTestHandler)
 	e.GET("/task", getTaskHandler)
-  	e.POST("/task", postTaskHandler)
+	e.POST("/task", postTaskHandler)
 
 	e.GET("/condition", getConditionHandler)
 

--- a/src/main.go
+++ b/src/main.go
@@ -54,7 +54,7 @@ func main() {
 	e.GET("/ping", pingHandler)
 	e.GET("/tasktest", getTaskTestHandler)
 	e.GET("/task", getTaskHandler)
-  e.POST("/task", postTaskHandler)
+  	e.POST("/task", postTaskHandler)
 
 	e.GET("/condition", getConditionHandler)
 

--- a/src/model.go
+++ b/src/model.go
@@ -33,6 +33,9 @@ type TaskWithoutId struct {
 	DueDate     time.Time `json:"due_date" db:"due_date"`
 }
 type Condition struct {
-	Id int `json:"id"`
-	Name string `json:"name"`
+	Id int `json:"id" db:"condition_id"`
+	Name string `json:"name,omitempty" db:"condition"`
+}
+type ConditionRequestBody struct {
+	Name string `json:"name,omitempty" db:"condition"`
 }

--- a/src/model.go
+++ b/src/model.go
@@ -33,7 +33,7 @@ type TaskWithoutId struct {
 }
 type Condition struct {
 	Id int `json:"id" db:"condition_id"`
-	User string `json:"user" db:"user"`
+	User string `json:"user,omitempty" db:"user"`
 	Name string `json:"name,omitempty" db:"condition"`
 }
 type ConditionRequestBody struct {

--- a/src/model.go
+++ b/src/model.go
@@ -34,12 +34,17 @@ type TaskWithoutId struct {
 
 type Condition struct {
 	Id int `json:"id" db:"condition_id"`
-	User string `json:"user,omitempty" db:"user"`
-	Name string `json:"name,omitempty" db:"condition"`
+	User string `json:"user" db:"user"`
+	Name string `json:"name" db:"condition"`
+}
+
+type ConditionWithoutUser struct {
+	Id int `json:"id" db:"condition_id"`
+	Name string `json:"name" db:"condition"`
 }
 
 type ConditionRequestBody struct {
-	Name string `json:"name,omitempty" db:"condition"`
+	Name string `json:"name" db:"condition"`
 }
 
 // for suggestion

--- a/src/model.go
+++ b/src/model.go
@@ -34,6 +34,7 @@ type TaskWithoutId struct {
 }
 type Condition struct {
 	Id int `json:"id" db:"condition_id"`
+	User string `json:"user" db:"user"`
 	Name string `json:"name,omitempty" db:"condition"`
 }
 type ConditionRequestBody struct {


### PR DESCRIPTION
## GET: /condition
- get: /task とほぼ同様の実装

## POST: /condition  
- ConditionRequestBodyの定義
- リクエスト受取用
- 状態名は空白は不可能にしてある
- len(conditionreq.Name)==0 の条件で
- エラーハンドリングDB周り大体500(InternalServerError)で済ませていますが適切なのがあるかもしれません 

## DELETE: /condition/{id}
- idはconditionidに対応,condition作成者でないと削除できないよう対応