### PR TITLE
認証周り(4行目)で発生したエラーの修正 37行目のINSERTのコメントアウト

### DIFF
--- a/script/init.sql
+++ b/script/init.sql
@@ -1,8 +1,8 @@
 CREATE DATABASE IF NOT EXISTS `yaranai`;
 USE `yaranai`;
 CREATE USER yaranai IDENTIFIED BY 'password';
-GRANT ALL *.* TO yaranai;
-CREATE TABLE `task` (
+GRANT ALL PRIVILEGES ON yaranai.* TO 'yaranai'@'%';
+CREATE TABLE IF NOT EXISTS `task` (
   `user` text NOT NULL,
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `title` text NOT NULL,
@@ -14,7 +14,7 @@ CREATE TABLE `task` (
   `dueDate` date NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-CREATE TABLE `condition` (
+CREATE TABLE IF NOT EXISTS `condition` (
   `condition_id` int(11) NOT NULL AUTO_INCREMENT,
   `user` text NOT NULL,
   `condition` text NOT NULL,
@@ -33,5 +33,6 @@ CREATE TABLE IF NOT EXISTS `deleted_task` (
 ALTER TABLE `task` ADD FOREIGN KEY (`condition_id`) REFERENCES `condition`(`condition_id`);
 
 ALTER TABLE `deleted_task` ADD FOREIGN KEY (`condition_id`) REFERENCES `condition`(`condition_id`);
-INSERT INTO `task` (`user`,`id`,`title`,`description`,`condition_id`,`difficulty`,`created_at`,`updated_at`,`dueDate`) VALUES ('ramdos',1,'電磁気学の課題','第二回の講義までにやる',2,3,'2023-12-01','2023-12-05','2023-12-10');
+INSERT INTO `condition` (`condition_id`,`user`,`condition`) VALUES (1,'ramdos','anywhere');
+-- INSERT INTO `task` (`user`,`id`,`title`,`description`,`condition_id`,`difficulty`,`created_at`,`updated_at`,`dueDate`) VALUES ('ramdos',1,'電磁気学の課題','第二回の講義までにやる',2,3,'2023-12-01','2023-12-05','2023-12-10');
 


### PR DESCRIPTION
4行目については調べたものをコピペしたのみ
ただ毎回再セットアップの時に必要だった認可設定がなくなるのは良

37行目についてはcondition_id 1のconditionが存在しない状態でcondition_id 1のtaskをINSERTしようとしたために外部キー制約に引っかかってるようです。しかし、その前にconditionを追加するようにしても同様のエラーが出たことからいったんコメントアウトすることでmysqlが起動失敗することを避けました